### PR TITLE
minor: Add EclipseStore caching

### DIFF
--- a/eclipsestore-cache/build.gradle.kts
+++ b/eclipsestore-cache/build.gradle.kts
@@ -2,6 +2,13 @@ plugins {
     id("io.micronaut.internal.build.eclipsestore-module")
 }
 
+// REMOVE ONCE FIRST RELEASE IS RELEASED
+micronautBuild {
+    binaryCompatibility {
+        enabled.set(false)
+    }
+}
+
 dependencies {
     api(projects.micronautEclipsestore)
     api(libs.managed.eclipsestore.cache)

--- a/eclipsestore-cache/build.gradle.kts
+++ b/eclipsestore-cache/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    id("io.micronaut.internal.build.eclipsestore-module")
+}
+
+dependencies {
+    api(projects.micronautEclipsestore)
+    api(libs.managed.eclipsestore.cache)
+    api(mnCache.micronaut.cache.core)
+    testImplementation(mnCache.micronaut.cache.tck)
+    testImplementation(libs.jupiter.api)
+}

--- a/eclipsestore-cache/src/main/java/io/micronaut/eclipsestore/cache/CacheConfiguration.java
+++ b/eclipsestore-cache/src/main/java/io/micronaut/eclipsestore/cache/CacheConfiguration.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.eclipsestore.cache;
+
+import io.micronaut.context.annotation.DefaultImplementation;
+import io.micronaut.core.util.Toggleable;
+
+/**
+ * Global EclipseStore Cache configuration.
+ * {@link CacheConfiguration} and {@link CacheConfigurationProperties} exist to generate configuration reference documentation automatically.
+ * we generate documentation reference.
+ *
+ * @author Sergio del Amo
+ * @since 1.3.0
+ */
+@DefaultImplementation(CacheConfigurationProperties.class)
+public interface CacheConfiguration extends Toggleable {
+}

--- a/eclipsestore-cache/src/main/java/io/micronaut/eclipsestore/cache/CacheConfigurationFactory.java
+++ b/eclipsestore-cache/src/main/java/io/micronaut/eclipsestore/cache/CacheConfigurationFactory.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.eclipsestore.cache;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.exceptions.DisabledBeanException;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.naming.Named;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import jakarta.inject.Singleton;
+import org.eclipse.serializer.configuration.types.Configuration;
+import org.eclipse.store.cache.types.CacheConfigurationBuilderConfigurationBased;
+import org.eclipse.store.cache.types.CacheConfiguration;
+import org.eclipse.store.cache.types.CacheConfigurationPropertyNames;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.eclipse.store.storage.types.StorageManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+
+/**
+ * Creates a {@link org.eclipse.store.cache.types.CacheConfiguration.Builder} for each {@link EclipseStoreCacheConfiguration}.
+ *
+ * @param <K> Key Type
+ * @param <V> Value Type
+ * @author Sergio del Amo
+ * @since 1.3.0
+ */
+@Factory
+public class CacheConfigurationFactory<K, V> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CacheConfigurationFactory.class);
+
+    private final BeanContext beanContext;
+
+    /**
+     * @param beanContext Bean Context
+     */
+    public CacheConfigurationFactory(BeanContext beanContext) {
+        this.beanContext = beanContext;
+    }
+
+    /**
+     * Creates a {@link org.eclipse.store.cache.types.CacheConfiguration.Builder} for each {@link EclipseStoreCacheConfiguration}.
+     *
+     * @param cacheConfiguration Cache Configuration
+     * @return Cache Configuration Builder
+     */
+    @EachBean(EclipseStoreCacheConfiguration.class)
+    @Singleton
+    public CacheConfiguration.Builder<K, V> createCacheConfigurationProvider(EclipseStoreCacheConfiguration<K, V> cacheConfiguration) {
+        if (!cacheConfiguration.isEnabled()) {
+            throw new DisabledBeanException("EclipseStore cache " + cacheConfiguration.getName() + " is disabled");
+        }
+        EmbeddedStorageManager embeddedStorageManager = (EmbeddedStorageManager) findStorageManager(cacheConfiguration)
+            .filter(EmbeddedStorageManager.class::isInstance)
+            .orElse(null);
+        CacheConfiguration.Builder<K, V> cacheConfigurationBuilder = embeddedStorageManager == null ? CacheConfiguration.Builder(cacheConfiguration.getKeyType(),
+            cacheConfiguration.getValueType()) : CacheConfiguration.Builder(cacheConfiguration.getKeyType(),
+            cacheConfiguration.getValueType(),
+            cacheConfiguration.getName(),
+            embeddedStorageManager);
+        CacheConfiguration.Builder<K, V> builder = CacheConfigurationBuilderConfigurationBased.New()
+            .buildCacheConfiguration(createConfiguration(cacheConfiguration), cacheConfigurationBuilder);
+        findExpiryPolicyFactory(cacheConfiguration)
+            .ifPresent(expiryPolicyFactory -> builder.expiryPolicyFactory(expiryPolicyFactory.getFactory()));
+        return builder;
+    }
+
+    @NonNull
+    private Optional<StorageManager> findStorageManager(EclipseStoreCacheConfiguration<K, V> cacheConfiguration) {
+        return Optional.ofNullable(cacheConfiguration.getStorage())
+            .flatMap(storageNameQualifier -> {
+                if (LOG.isWarnEnabled() && !beanContext.containsBean(StorageManager.class, Qualifiers.byName(storageNameQualifier))) {
+                    LOG.warn("No Storage Manager qualified by name {}", storageNameQualifier);
+                }
+                return beanContext.findBean(StorageManager.class, Qualifiers.byName(storageNameQualifier));
+            });
+    }
+
+    @NonNull
+    private Configuration createConfiguration(@NonNull EclipseStoreCacheConfiguration<K, V> cacheConfiguration) {
+        Configuration.Builder configurationBuilder = Configuration.Builder();
+        booleanString(cacheConfiguration.isReadThrough()).ifPresent(b ->
+            configurationBuilder.set(CacheConfigurationPropertyNames.READ_THROUGH, b));
+        booleanString(cacheConfiguration.isWriteThrough()).ifPresent(b ->
+            configurationBuilder.set(CacheConfigurationPropertyNames.WRITE_THROUGH, b));
+        booleanString(cacheConfiguration.isStoreByValue()).ifPresent(b ->
+            configurationBuilder.set(CacheConfigurationPropertyNames.STORE_BY_VALUE, b));
+        booleanString(cacheConfiguration.isStatisticsEnabled()).ifPresent(b ->
+            configurationBuilder.set(CacheConfigurationPropertyNames.STATISTICS_ENABLED, b));
+        booleanString(cacheConfiguration.isManagementEnabled()).ifPresent(b ->
+            configurationBuilder.set(CacheConfigurationPropertyNames.MANAGEMENT_ENABLED, b));
+        return configurationBuilder.buildConfiguration();
+    }
+
+    @NonNull
+    private Optional<ExpiryPolicyFactory> findExpiryPolicyFactory(@NonNull Named named) {
+        return beanContext.findBean(ExpiryPolicyFactory.class, Qualifiers.byName(named.getName()));
+    }
+
+    @NonNull
+    private Optional<String> booleanString(Boolean value) {
+        if (value == null) {
+            return Optional.empty();
+        }
+        return Optional.of(value ? StringUtils.TRUE : StringUtils.FALSE);
+    }
+}

--- a/eclipsestore-cache/src/main/java/io/micronaut/eclipsestore/cache/CacheConfigurationProperties.java
+++ b/eclipsestore-cache/src/main/java/io/micronaut/eclipsestore/cache/CacheConfigurationProperties.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.eclipsestore.cache;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+
+/**
+ * Configuration for EclipseStore Cache module.
+ * {@link CacheConfiguration} and {@link CacheConfigurationProperties} exist to generate configuration reference documentation automatically.
+ * It uses a different class because {@link EclipseStoreCacheConfigurationProperties} is a {@link io.micronaut.context.annotation.EachProperty} implementation.
+ *
+ * @author Sergio del Amo
+ * @since 1.3.0
+ */
+@ConfigurationProperties(EclipseStoreCacheConfigurationProperties.PREFIX)
+public class CacheConfigurationProperties implements CacheConfiguration {
+
+    /**
+     * Whether EclipseStore Cache module is enabled.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static final boolean DEFAULT_ENABLED = true;
+
+    private boolean enabled = DEFAULT_ENABLED;
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Whether EclipseStore Cache module is enabled. Default Value: {@value CacheConfigurationProperties#DEFAULT_ENABLED}
+     *
+     * @param enabled Whether this cache is enabled.
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/eclipsestore-cache/src/main/java/io/micronaut/eclipsestore/cache/CacheFactory.java
+++ b/eclipsestore-cache/src/main/java/io/micronaut/eclipsestore/cache/CacheFactory.java
@@ -69,7 +69,7 @@ public class CacheFactory {
     public <K, V> EclipseStoreSyncCache<K, V> createCache(
         @Parameter String name,
         CacheConfiguration.Builder<K, V> cacheConfigurationBuilder,
-        @Named(TaskExecutors.IO) ExecutorService executorService
+        @Named(TaskExecutors.BLOCKING) ExecutorService executorService
     ) {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Creating cache: {}", name);

--- a/eclipsestore-cache/src/main/java/io/micronaut/eclipsestore/cache/CacheFactory.java
+++ b/eclipsestore-cache/src/main/java/io/micronaut/eclipsestore/cache/CacheFactory.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.eclipsestore.cache;
+
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.scheduling.TaskExecutors;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.eclipse.store.cache.types.CacheConfiguration;
+
+import javax.cache.CacheManager;
+import javax.cache.Caching;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * @author Tim Yates
+ * @since 1.3.0
+ */
+@Factory
+public class CacheFactory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CacheFactory.class);
+    private static final String ECLIPSE_STORE_CACHING_PROVIDER = "org.eclipse.store.cache.types.CachingProvider";
+    private final CacheManager manager;
+    private final ConversionService conversionService;
+
+    /**
+     * Constructor.
+     *
+     * @param conversionService The conversion service
+     */
+    public CacheFactory(ConversionService conversionService) {
+        this.conversionService = conversionService;
+        this.manager = Caching.getCachingProvider(ECLIPSE_STORE_CACHING_PROVIDER).getCacheManager();
+    }
+
+    /**
+     * Create a cache for each CacheConfiguration.
+     *
+     * @param name                      The name of the cache
+     * @param cacheConfigurationBuilder Cache Configuration Builder
+     * @param <K>                       The key type
+     * @param <V>                       The key type
+     * @param executorService           The IO executor service for async caches
+     * @return The cache
+     */
+    @Singleton
+    @Bean(preDestroy = "close")
+    @EachBean(CacheConfiguration.Builder.class)
+    public <K, V> EclipseStoreSyncCache<K, V> createCache(
+        @Parameter String name,
+        CacheConfiguration.Builder<K, V> cacheConfigurationBuilder,
+        @Named(TaskExecutors.IO) ExecutorService executorService
+    ) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Creating cache: {}", name);
+        }
+        return new EclipseStoreSyncCache<>(manager.createCache(name, cacheConfigurationBuilder.build()), conversionService, executorService);
+    }
+}

--- a/eclipsestore-cache/src/main/java/io/micronaut/eclipsestore/cache/EclipseStoreCacheConfiguration.java
+++ b/eclipsestore-cache/src/main/java/io/micronaut/eclipsestore/cache/EclipseStoreCacheConfiguration.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.eclipsestore.cache;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.naming.Named;
+import io.micronaut.core.util.Toggleable;
+
+/**
+ * EclipseStore Cache Configuration.
+ *
+ * @param <K> Key Type
+ * @param <V> Value Type
+ * @author Sergio del Amo
+ * @since 1.3.0
+ */
+public interface EclipseStoreCacheConfiguration<K, V> extends Named, Toggleable {
+    /**
+     * @return The required type of keys for the Cache.
+     */
+    @NonNull
+    Class<K> getKeyType();
+
+    /**
+     * @return Determines type of values for the Cache.
+     */
+    @NonNull
+    Class<V> getValueType();
+
+    /**
+     * @return Name qualifier for Storage Manager.
+     */
+    @Nullable
+    String getStorage();
+
+    /**
+     * When in "read-through" mode, cache misses that occur due to cache entries not existing as a result of performing a "get" will appropriately cause the configured CacheLoader to be invoked.
+     *
+     * @return Whether to use "read-through" mode
+     */
+    @Nullable
+    Boolean isReadThrough();
+
+    /**
+     * When in "write-through" mode, cache updates that occur as a result of performing "put" operations will appropriately cause the configured CacheWriter to be invoked.
+     *
+     * @return Whether to use "write-through" mode.
+     */
+    @Nullable
+    Boolean isWriteThrough();
+
+    /**
+     * When a cache is storeByValue, any mutation to the key or value does not affect the key of value stored in the cache.
+     *
+     * @return Whether the cache is Story by value.
+     */
+    @Nullable
+    Boolean isStoreByValue();
+
+    /**
+     * Whether statistics collection is enabled in this cache.
+     *
+     * @return Whether statistics collection is enabled in this cache.
+     */
+    @Nullable
+    Boolean isStatisticsEnabled();
+
+    /**
+     * Whether management is enabled on this cache.
+     *
+     * @return Whether management is enabled on this cache.
+     */
+    @Nullable
+    Boolean isManagementEnabled();
+}

--- a/eclipsestore-cache/src/main/java/io/micronaut/eclipsestore/cache/EclipseStoreCacheConfigurationProperties.java
+++ b/eclipsestore-cache/src/main/java/io/micronaut/eclipsestore/cache/EclipseStoreCacheConfigurationProperties.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.eclipsestore.cache;
+
+import io.micronaut.context.annotation.EachProperty;
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+
+/**
+ * @param <K> Key Type
+ * @param <V> Value Type
+ * @author Sergio del Amo
+ * @since 1.3.0
+ */
+@EachProperty(EclipseStoreCacheConfigurationProperties.PREFIX)
+public class EclipseStoreCacheConfigurationProperties<K, V> implements EclipseStoreCacheConfiguration<K, V> {
+
+    public static final String PREFIX = "eclipsestore.cache";
+
+    /**
+     * Whether this cache is enabled by default.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static final boolean DEFAULT_ENABLED = true;
+    private final String name;
+    private boolean enabled = DEFAULT_ENABLED;
+    @Nullable
+    private Class<K> keyType;
+    @Nullable
+    private Class<V> valueType;
+    @Nullable
+    private String storage;
+    @Nullable
+    private Boolean readThrough;
+    @Nullable
+    private Boolean writeThrough;
+    @Nullable
+    private Boolean storeByValue;
+    @Nullable
+    private Boolean statisticsEnabled;
+    @Nullable
+    private Boolean managementEnabled;
+
+    public EclipseStoreCacheConfigurationProperties(@Parameter String name) {
+        this.name = name;
+    }
+
+    @Override
+    @NonNull
+    public Class<K> getKeyType() {
+        return keyType != null ? keyType : (Class<K>) Object.class;
+    }
+
+    /**
+     * @param keyType The required type of keys for the Cache.
+     */
+    public void setKeyType(@Nullable Class<K> keyType) {
+        this.keyType = keyType;
+    }
+
+    @Override
+    @NonNull
+    public Class<V> getValueType() {
+        return valueType != null ? valueType : (Class<V>) Object.class;
+    }
+
+    /**
+     * @param valueType Determines type of values for the Cache.
+     */
+    public void setValueType(@Nullable Class<V> valueType) {
+        this.valueType = valueType;
+    }
+
+    @Nullable
+    @Override
+    public String getStorage() {
+        return storage;
+    }
+
+    /**
+     * @param storage Name qualifier for EclipseStore Storage Manager
+     */
+    public void setStorage(@Nullable String storage) {
+        this.storage = storage;
+    }
+
+    @Override
+    @Nullable
+    public Boolean isReadThrough() {
+        return readThrough;
+    }
+
+    @Override
+    @Nullable
+    public Boolean isWriteThrough() {
+        return writeThrough;
+    }
+
+    @Override
+    @Nullable
+    public Boolean isStoreByValue() {
+        return storeByValue;
+    }
+
+    @Override
+    @Nullable
+    public Boolean isStatisticsEnabled() {
+        return statisticsEnabled;
+    }
+
+    @Override
+    @Nullable
+    public Boolean isManagementEnabled() {
+        return managementEnabled;
+    }
+
+    @Override
+    @NonNull
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * When in "read-through" mode, cache misses that occur due to cache entries not existing as a result of performing a "get" will appropriately cause the configured CacheLoader to be invoked. When you set a Storage Manager, "read-through" mode is activated.
+     *
+     * @param readThrough Whether to use "read-through" mode
+     */
+    public void setReadThrough(Boolean readThrough) {
+        this.readThrough = readThrough;
+    }
+
+    /**
+     * When in "write-through" mode, cache updates that occur as a result of performing "put" operations will appropriately cause the configured CacheWriter to be invoked.When you set a Storage Manager, "write-through" mode is activated.
+     *
+     * @param writeThrough Whether to use "write-through" mode.
+     */
+    public void setWriteThrough(Boolean writeThrough) {
+        this.writeThrough = writeThrough;
+    }
+
+    /**
+     * When a cache is storeByValue, any mutation to the key or value does not affect the key of value stored in the cache.
+     *
+     * @param storeByValue When a cache is storeByValue, any mutation to the key or value does not affect the key of value stored in the cache.
+     */
+    public void setStoreByValue(Boolean storeByValue) {
+        this.storeByValue = storeByValue;
+    }
+
+    /**
+     * Whether statistics collection is enabled in this cache.
+     *
+     * @param statisticsEnabled Whether statistics collection is enabled in this cache.
+     */
+    public void setStatisticsEnabled(Boolean statisticsEnabled) {
+        this.statisticsEnabled = statisticsEnabled;
+    }
+
+    /**
+     * Whether management is enabled on this cache.
+     *
+     * @param managementEnabled Whether management is enabled on this cache.
+     */
+    public void setManagementEnabled(Boolean managementEnabled) {
+        this.managementEnabled = managementEnabled;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Whether this cache is enabled. Default Value: {@value #DEFAULT_ENABLED}
+     *
+     * @param enabled Whether this cache is enabled.
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/eclipsestore-cache/src/main/java/io/micronaut/eclipsestore/cache/EclipseStoreSyncCache.java
+++ b/eclipsestore-cache/src/main/java/io/micronaut/eclipsestore/cache/EclipseStoreSyncCache.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.eclipsestore.cache;
+
+import io.micronaut.cache.jcache.JCacheSyncCache;
+import io.micronaut.core.convert.ConversionService;
+
+import javax.cache.Cache;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * A {@link io.micronaut.cache.SyncCache} implementation that uses a EclipseStore Cache instance.
+ *
+ * @param <K> the key type
+ * @param <V> the value type
+ * @author Tim Yates
+ * @since 1.3.0
+ */
+public class EclipseStoreSyncCache<K, V> extends JCacheSyncCache implements AutoCloseable {
+
+    private final Cache<K, V> cache;
+
+    public EclipseStoreSyncCache(Cache<K, V> cache, ConversionService conversionService, ExecutorService executorService) {
+        super(cache, conversionService, executorService);
+        this.cache = cache;
+    }
+
+    @Override
+    public void close() {
+        cache.close();
+    }
+}

--- a/eclipsestore-cache/src/main/java/io/micronaut/eclipsestore/cache/ExpiryPolicyFactory.java
+++ b/eclipsestore-cache/src/main/java/io/micronaut/eclipsestore/cache/ExpiryPolicyFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.eclipsestore.cache;
+
+import javax.cache.configuration.Factory;
+import javax.cache.expiry.ExpiryPolicy;
+
+/**
+ * A marker class for defining an expiry policy on EclipseStore backed caches.
+ *
+ * @author Tim Yates
+ * @since 1.3.0
+ */
+public interface ExpiryPolicyFactory {
+
+    Factory<ExpiryPolicy> getFactory();
+}

--- a/eclipsestore-cache/src/main/java/io/micronaut/eclipsestore/cache/package-info.java
+++ b/eclipsestore-cache/src/main/java/io/micronaut/eclipsestore/cache/package-info.java
@@ -18,7 +18,7 @@
  *
  * @see <a href="https://micronaut-projects.github.io/micronaut-cache/latest/guide/">Micronaut Cache</a>
  * @author Tim Yates
- * @since 1.1.0
+ * @since 1.3.0
  */
 @Configuration
 @Requires(property = EclipseStoreCacheConfigurationProperties.PREFIX + ".enabled", notEquals = StringUtils.FALSE)

--- a/eclipsestore-cache/src/main/java/io/micronaut/eclipsestore/cache/package-info.java
+++ b/eclipsestore-cache/src/main/java/io/micronaut/eclipsestore/cache/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * EclipseStore classes related to caching.
+ *
+ * @see <a href="https://micronaut-projects.github.io/micronaut-cache/latest/guide/">Micronaut Cache</a>
+ * @author Tim Yates
+ * @since 1.1.0
+ */
+@Configuration
+@Requires(property = EclipseStoreCacheConfigurationProperties.PREFIX + ".enabled", notEquals = StringUtils.FALSE)
+package io.micronaut.eclipsestore.cache;
+
+import io.micronaut.context.annotation.Configuration;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;

--- a/eclipsestore-cache/src/test/groovy/io/micronaut/eclipsestore/cache/CacheConfigurationProviderSpec.groovy
+++ b/eclipsestore-cache/src/test/groovy/io/micronaut/eclipsestore/cache/CacheConfigurationProviderSpec.groovy
@@ -1,0 +1,123 @@
+package io.micronaut.eclipsestore.cache
+
+import io.micronaut.core.util.StringUtils
+import io.micronaut.eclipsestore.cache.ExpiryPolicyFactory
+import io.micronaut.context.BeanContext
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.inject.qualifiers.Qualifiers
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.inject.Named
+import jakarta.inject.Singleton
+import org.eclipse.store.cache.types.CacheConfiguration
+import spock.lang.Specification
+
+import javax.cache.Cache
+import javax.cache.configuration.Factory
+import javax.cache.expiry.CreatedExpiryPolicy
+import javax.cache.expiry.Duration
+import javax.cache.expiry.EternalExpiryPolicy
+import javax.cache.expiry.ExpiryPolicy
+
+@Property(name = "spec.name", value = "CacheConfigurationProviderSpec")
+// Storage properties
+@Property(name = "eclipsestore.storage.one.storage-directory", value = "build/eclipsestore")
+// Properties for first cache
+@Property(name = "eclipsestore.cache.one.key-type", value = "java.lang.Integer")
+@Property(name = "eclipsestore.cache.one.value-type", value = "java.lang.String")
+@Property(name = "eclipsestore.cache.one.statistics-enabled", value = StringUtils.TRUE)
+@Property(name = "eclipsestore.cache.one.storage", value = "one")
+// Properties for second cache
+@Property(name = "eclipsestore.cache.two.key-type", value = "java.lang.Character")
+@Property(name = "eclipsestore.cache.two.value-type", value = "java.lang.Float")
+@Property(name = "eclipsestore.cache.two.management-enabled", value = StringUtils.TRUE)
+// Properties for third cache
+@Property(name = "eclipsestore.cache.three.management-enabled", value = StringUtils.TRUE)
+// Properties for fourth cache
+@Property(name = "eclipsestore.cache.fourth.key-type", value = "java.lang.Character")
+@Property(name = "eclipsestore.cache.fourth.value-type", value = "java.lang.Float")
+@Property(name = "eclipsestore.cache.fourth.management-enabled", value = StringUtils.TRUE)
+@Property(name = "eclipsestore.cache.fourth.enabled", value = StringUtils.FALSE)
+@MicronautTest(startApplication = false)
+class CacheConfigurationProviderSpec extends Specification {
+
+    @Inject
+    BeanContext beanContext
+
+    void "you can have multiple beans of type CacheConfigurationProvider"() {
+        expect:
+        beanContext.getBeansOfType(CacheConfiguration.Builder).size() == 3
+
+        when:
+        CacheConfiguration.Builder oneProvider = beanContext.getBean(CacheConfiguration.Builder, Qualifiers.byName("one"))
+
+        then:
+        with(oneProvider.build()) {
+            keyType == Integer
+            valueType == String
+            readThrough // When you set a Storage Manager, "read-through" mode is activated.
+            writeThrough // When you set a Storage Manager, "write-through" mode is activated.
+            !managementEnabled
+            statisticsEnabled
+            expiryPolicyFactory.create() instanceof EternalExpiryPolicy
+        }
+
+        when:
+        CacheConfiguration.Builder twoProvider = beanContext.getBean(CacheConfiguration.Builder, Qualifiers.byName("two"))
+
+        then:
+        with(twoProvider.build()) {
+            keyType == Character
+            valueType == Float
+            !readThrough
+            !writeThrough
+            managementEnabled
+            !statisticsEnabled
+            with(expiryPolicyFactory.create()) {
+                it instanceof CreatedExpiryPolicy
+                it.expiryForCreation == Duration.FIVE_MINUTES
+            }
+        }
+
+        when:
+        CacheConfiguration.Builder threeProvider = beanContext.getBean(CacheConfiguration.Builder, Qualifiers.byName("three"))
+
+        then: 'no type specified, so defaults to Object'
+        with(threeProvider.build()) {
+            keyType == Object
+            valueType == Object
+            managementEnabled
+        }
+    }
+
+    @Named("two")
+    @Singleton
+    @Requires(property = "spec.name", value = "CacheConfigurationProviderSpec")
+    static class TwoFiveMinuteExpiryPolicy implements ExpiryPolicyFactory {
+
+        @Override
+        Factory<ExpiryPolicy> getFactory() {
+            return CreatedExpiryPolicy.factoryOf(Duration.FIVE_MINUTES)
+        }
+    }
+
+    @Requires(property = "spec.name", value = "CacheConfigurationProviderSpec")
+    @Controller
+    static class CacheConfigurationProviderController {
+
+        private final Cache<Integer, String> cache
+
+        CacheConfigurationProviderController(@Named("one") Cache<Integer, String> cache) {
+            this.cache = cache
+        }
+
+        @Get()
+        def index() {
+            cache.toString()
+        }
+    }
+
+}

--- a/eclipsestore-cache/src/test/groovy/io/micronaut/eclipsestore/cache/CachePersistenceSpec.groovy
+++ b/eclipsestore-cache/src/test/groovy/io/micronaut/eclipsestore/cache/CachePersistenceSpec.groovy
@@ -1,0 +1,92 @@
+package io.micronaut.eclipsestore.cache
+
+import io.micronaut.cache.SyncCache
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.type.Argument
+import io.micronaut.inject.qualifiers.Qualifiers
+import spock.lang.Specification
+
+class CachePersistenceSpec extends Specification {
+
+    def "cache remains over restarts"() {
+        given:
+        def properties = [
+                "eclipsestore.storage.cachestore.storage-directory": "build/eclipsestore-${UUID.randomUUID().toString()}",
+                "eclipsestore.cache.backed.key-type"               : "java.lang.Integer",
+                "eclipsestore.cache.backed.value-type"             : "java.lang.String",
+                "eclipsestore.cache.backed.statistics-enabled"     : "true",
+                "eclipsestore.cache.backed.storage"                : "cachestore",
+                "eclipsestore.cache.unbacked.statistics-enabled"   : "true",
+        ]
+
+        def applicationContext = ApplicationContext.run(properties)
+
+        when: 'we cache some data in the backed cache'
+        def backedCache = applicationContext.getBean(SyncCache.class, Qualifiers.byName("backed"))
+        backedCache.put(1, "This is some data to cache")
+
+        and: 'we cache some data in the unbacked cache'
+        def unbackedCache = applicationContext.getBean(SyncCache.class, Qualifiers.byName("unbacked"))
+        unbackedCache.put(2, "And here is some more data")
+
+        then:
+        backedCache.get(1, Argument.of(String)).get() == "This is some data to cache"
+        unbackedCache.get(2, Argument.of(String)).get() == "And here is some more data"
+
+        when: 'we restart the app with the same backing data store'
+        applicationContext.stop()
+        applicationContext = ApplicationContext.run(properties)
+        backedCache = applicationContext.getBean(SyncCache.class, Qualifiers.byName("backed"))
+        unbackedCache = applicationContext.getBean(SyncCache.class, Qualifiers.byName("unbacked"))
+
+        then: 'the data is still there in the backed cache'
+        backedCache.get(1, Argument.of(String)).get() == "This is some data to cache"
+
+        and: 'it is not in the unbacked cache'
+        !unbackedCache.get(2, Argument.of(String)).present
+
+        cleanup:
+        applicationContext.stop()
+    }
+
+    def "async cache remains over restarts"() {
+        given:
+        def properties = [
+                "eclipsestore.storage.cachestore.storage-directory": "build/eclipsestore-${UUID.randomUUID().toString()}",
+                "eclipsestore.cache.backed.key-type"               : "java.lang.Integer",
+                "eclipsestore.cache.backed.value-type"             : "java.lang.String",
+                "eclipsestore.cache.backed.statistics-enabled"     : "true",
+                "eclipsestore.cache.backed.storage"                : "cachestore",
+                "eclipsestore.cache.unbacked.statistics-enabled"   : "true",
+        ]
+
+        def applicationContext = ApplicationContext.run(properties)
+
+        when: 'we cache some data in the backed cache'
+        def backedCache = applicationContext.getBean(SyncCache.class, Qualifiers.byName("backed")).async()
+        backedCache.put(1, "This is some data to cache").get()
+
+        and: 'we cache some data in the unbacked cache'
+        def unbackedCache = applicationContext.getBean(SyncCache.class, Qualifiers.byName("unbacked")).async()
+        unbackedCache.put(2, "And here is some more data").get()
+
+        then:
+        backedCache.get(1, Argument.of(String)).get().get() == "This is some data to cache"
+        unbackedCache.get(2, Argument.of(String)).get().get() == "And here is some more data"
+
+        when: 'we restart the app with the same backing data store'
+        applicationContext.stop()
+        applicationContext = ApplicationContext.run(properties)
+        backedCache = applicationContext.getBean(SyncCache.class, Qualifiers.byName("backed")).async()
+        unbackedCache = applicationContext.getBean(SyncCache.class, Qualifiers.byName("unbacked")).async()
+
+        then: 'the data is still there in the backed cache'
+        backedCache.get(1, Argument.of(String)).get().get() == "This is some data to cache"
+
+        and: 'it is not in the unbacked cache'
+        !unbackedCache.get(2, Argument.of(String)).get().present
+
+        cleanup:
+        applicationContext.stop()
+    }
+}

--- a/eclipsestore-cache/src/test/groovy/io/micronaut/eclipsestore/cache/EclipseStoreAsyncCacheSpec.groovy
+++ b/eclipsestore-cache/src/test/groovy/io/micronaut/eclipsestore/cache/EclipseStoreAsyncCacheSpec.groovy
@@ -1,0 +1,26 @@
+package io.micronaut.eclipsestore.cache
+
+import io.micronaut.cache.tck.AbstractAsyncCacheSpec
+import io.micronaut.context.ApplicationContext
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.TempDir
+
+class EclipseStoreAsyncCacheSpec extends AbstractAsyncCacheSpec {
+
+    @TempDir
+    @Shared
+    File tempDir
+
+    @AutoCleanup
+    ApplicationContext applicationContext
+
+    @Override
+    ApplicationContext createApplicationContext() {
+        this.applicationContext = ApplicationContext.run(
+                'eclipsestore.cache.counter.statistics-enabled': "true",
+                'eclipsestore.cache.counter2.statistics-enabled': "true",
+                'eclipsestore.cache.test.statistics-enabled': "true",
+        )
+    }
+}

--- a/eclipsestore-cache/src/test/groovy/io/micronaut/eclipsestore/cache/EclipseStoreCacheDisabledSpec.groovy
+++ b/eclipsestore-cache/src/test/groovy/io/micronaut/eclipsestore/cache/EclipseStoreCacheDisabledSpec.groovy
@@ -1,0 +1,20 @@
+package io.micronaut.eclipsestore.cache
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.util.StringUtils
+import spock.lang.Specification
+
+class EclipseStoreCacheDisabledSpec extends Specification {
+
+    void "you can disable cache by setting eclipsestore.cache.enabled to false"() {
+        given:
+        ApplicationContext context = ApplicationContext.run(
+                ['eclipsestore.cache.enabled': StringUtils.FALSE])
+
+        expect:
+        !context.containsBean(CacheConfiguration.class)
+
+        cleanup:
+        context.close()
+    }
+}

--- a/eclipsestore-cache/src/test/groovy/io/micronaut/eclipsestore/cache/EclipseStoreSyncCacheSpec.groovy
+++ b/eclipsestore-cache/src/test/groovy/io/micronaut/eclipsestore/cache/EclipseStoreSyncCacheSpec.groovy
@@ -1,0 +1,26 @@
+package io.micronaut.eclipsestore.cache
+
+import io.micronaut.cache.tck.AbstractSyncCacheSpec
+import io.micronaut.context.ApplicationContext
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.TempDir
+
+class EclipseStoreSyncCacheSpec extends AbstractSyncCacheSpec {
+
+    @TempDir
+    @Shared
+    File tempDir
+
+    @AutoCleanup
+    ApplicationContext applicationContext
+
+    @Override
+    ApplicationContext createApplicationContext() {
+        this.applicationContext = ApplicationContext.run(
+                'eclipsestore.cache.counter.statistics-enabled': "true",
+                'eclipsestore.cache.counter2.statistics-enabled': "true",
+                'eclipsestore.cache.test.statistics-enabled': "true",
+        )
+    }
+}

--- a/eclipsestore-cache/src/test/resources/logback.xml
+++ b/eclipsestore-cache/src/test/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,9 +4,10 @@ micronaut = "4.3.1"
 groovy = "4.0.17"
 kotlin = '1.9.22'
 spock = "2.3-groovy-4.0"
-managed-eclipsestore='1.0.0'
+managed-eclipsestore='1.1.0'
 
 micronaut-aws = "4.4.0"
+micronaut-cache = "4.2.1"
 micronaut-logging = "1.2.2"
 micronaut-micrometer = "5.3.0"
 micronaut-serde = "2.7.1"
@@ -17,6 +18,7 @@ micronaut-validation = "4.3.0"
 
 [libraries]
 micronaut-aws = { module = "io.micronaut.aws:micronaut-aws-bom", version.ref = "micronaut-aws" }
+micronaut-cache = { module = "io.micronaut.cache:micronaut-cache-bom", version.ref = "micronaut-cache" }
 # Required to get dependabot updates for micronaut-core
 micronaut-core = { module = 'io.micronaut:micronaut-core-bom', version.ref = 'micronaut' }
 micronaut-micrometer = { module = "io.micronaut.micrometer:micronaut-micrometer-bom", version.ref = "micronaut-micrometer" }
@@ -27,6 +29,7 @@ micronaut-validation = { module = "io.micronaut.validation:micronaut-validation-
 
 managed-eclipsestore-aws-s3 = { module = 'org.eclipse.store:afs-aws-s3', version.ref = 'managed-eclipsestore' }
 managed-eclipsestore-aws-dynamodb = { module = 'org.eclipse.store:afs-aws-dynamodb', version.ref = 'managed-eclipsestore' }
+managed-eclipsestore-cache = { module = 'org.eclipse.store:cache', version.ref = 'managed-eclipsestore' }
 managed-eclipsestore-sql = { module = 'org.eclipse.store:afs-sql', version.ref = 'managed-eclipsestore' }
 managed-eclipsestore-storage-embedded-configuration = { module = 'org.eclipse.store:storage-embedded-configuration', version.ref = 'managed-eclipsestore' }
 managed-eclipsestore-storage-restservice = { module = 'org.eclipse.store:storage-restservice', version.ref = 'managed-eclipsestore' }

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,6 +14,7 @@ rootProject.name = 'eclipsestore-parent'
 include 'eclipsestore-bom'
 include 'eclipsestore'
 include 'eclipsestore-annotations'
+include 'eclipsestore-cache'
 include 'eclipsestore-rest'
 
 include 'test-suite'
@@ -29,6 +30,7 @@ micronautBuild {
     useStandardizedProjectNames = true
     importMicronautCatalog()
     importMicronautCatalog("micronaut-aws")
+    importMicronautCatalog("micronaut-cache")
     importMicronautCatalog("micronaut-micrometer")
     importMicronautCatalog("micronaut-serde")
     importMicronautCatalog("micronaut-sql")

--- a/src/main/docs/guide/cache.adoc
+++ b/src/main/docs/guide/cache.adoc
@@ -1,0 +1,2 @@
+EclipseStore can be used as a https://micronaut-projects.github.io/micronaut-cache/latest/guide/#cache-abstraction[cache abstraction] layer.
+

--- a/src/main/docs/guide/cache/cacheConfiguration.adoc
+++ b/src/main/docs/guide/cache/cacheConfiguration.adoc
@@ -1,0 +1,21 @@
+To use the EclipseStore cache abstraction, you must declare a dependency on
+
+dependency:micronaut-eclipsestore-cache[groupId="io.micronaut.eclipsestore"]
+
+You can then define a cache by adding the following configuration to your application:
+
+[source,yaml]
+.src/main/resources/application.yml
+----
+include::test-suite/src/test/resources/application-cache.yml[]
+----
+
+<1> Define a cache named `counter` which has String keys and Long values.
+
+This cache can then be used via the following:
+
+snippet::io.micronaut.eclipsestore.docs.CounterService[]
+
+<1> Use the `counter` cache.
+<2> The result of this call will be cached.
+<3> Setting the counter will invalidate the cache for this key.

--- a/src/main/docs/guide/cache/cacheConfiguration.adoc
+++ b/src/main/docs/guide/cache/cacheConfiguration.adoc
@@ -4,7 +4,7 @@ dependency:micronaut-eclipsestore-cache[groupId="io.micronaut.eclipsestore"]
 
 You can then define a cache by adding the following configuration to your application:
 
-[source,yaml]
+[configuration]
 .src/main/resources/application.yml
 ----
 include::test-suite/src/test/resources/application-cache.yml[]

--- a/src/main/docs/guide/cache/cacheStorage.adoc
+++ b/src/main/docs/guide/cache/cacheStorage.adoc
@@ -1,0 +1,13 @@
+If caching that persists across restarts is required, you can back a EclipseStore cache with a Storage Manager.
+
+[source,yaml]
+.src/main/resources/application.yml
+----
+include::test-suite/src/test/resources/application-cachepersist.yml[]
+----
+
+<1> Define a storage manager called `backing`
+<2> Define a cache called `counter` to store Strings keys and Long values
+<3> Configure the cache to use the `backing` storage manager
+
+The above example will then persist across restarts.

--- a/src/main/docs/guide/cache/cacheStorage.adoc
+++ b/src/main/docs/guide/cache/cacheStorage.adoc
@@ -1,6 +1,6 @@
 If caching that persists across restarts is required, you can back a EclipseStore cache with a Storage Manager.
 
-[source,yaml]
+[configuration]
 .src/main/resources/application.yml
 ----
 include::test-suite/src/test/resources/application-cachepersist.yml[]

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -14,6 +14,10 @@ storageTargets:
   postgres: Postgres
   s3: S3
   dynamodb: DynamoDB
+cache:
+  title: Cache
+  cacheConfiguration: Cache Configuration
+  cacheStorage: Cache Storage
 eclipsestoreMetrics: Metrics
 storageHealth: Health
 rest:

--- a/test-suite-groovy/build.gradle
+++ b/test-suite-groovy/build.gradle
@@ -4,14 +4,18 @@ plugins {
 }
 
 dependencies {
-    testImplementation(platform(mn.micronaut.core.bom))
     testCompileOnly(mn.micronaut.inject.groovy)
+
+    testImplementation(platform(mn.micronaut.core.bom))
+    testImplementation(projects.micronautEclipsestore)
     testImplementation(projects.micronautEclipsestoreAnnotations)
+    testImplementation(projects.micronautEclipsestoreCache)
     testImplementation(mnValidation.micronaut.validation)
     testImplementation(mnSerde.micronaut.serde.jackson)
     testImplementation(mnTest.micronaut.test.spock)
     testImplementation(mn.micronaut.http.server.netty)
     testImplementation(mn.micronaut.http.client)
-    testImplementation(projects.micronautEclipsestore)
+
+    testRuntimeOnly(mn.snakeyaml)
     testRuntimeOnly(mnLogging.logback.classic)
 }

--- a/test-suite-groovy/src/test/groovy/io/micronaut/eclipsestore/docs/CacheSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/eclipsestore/docs/CacheSpec.groovy
@@ -1,0 +1,33 @@
+package io.micronaut.eclipsestore.docs
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.Specification
+
+class CacheSpec extends Specification {
+
+    void 'cache works as expected'() {
+        given:
+        def config = [storageDirectory: "build/eclipsestore-cache-${UUID.randomUUID()}"]
+        def server = ApplicationContext.run(EmbeddedServer.class, config, "cache")
+
+        CounterService counter = server.applicationContext.getBean(CounterService)
+
+        when:
+        counter.setCount("Tim", 1337)
+        Long count = counter.currentCount("Tim")
+
+        then:
+        count == 1337
+
+        when: "Change the store so we check we're seeing a cached value"
+        counter.counters.Tim = -1
+        count = counter.currentCount("Tim")
+
+        then:
+        count == 1337
+
+        cleanup:
+        server.stop()
+    }
+}

--- a/test-suite-groovy/src/test/groovy/io/micronaut/eclipsestore/docs/CounterService.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/eclipsestore/docs/CounterService.groovy
@@ -1,0 +1,24 @@
+package io.micronaut.eclipsestore.docs
+
+import io.micronaut.cache.annotation.CacheConfig
+import io.micronaut.cache.annotation.CachePut
+import io.micronaut.cache.annotation.Cacheable
+import jakarta.inject.Singleton
+
+@Singleton
+@CacheConfig("counter") // <1>
+class CounterService {
+
+    Map<String, Long> counters = [:]
+
+    @Cacheable // <2>
+    Long currentCount(String name) {
+        return counters.get(name)
+    }
+
+    @CachePut(parameters = ["name"]) // <3>
+    Long setCount(String name, Long count) {
+        counters.put(name, count)
+        count
+    }
+}

--- a/test-suite-groovy/src/test/groovy/io/micronaut/eclipsestore/docs/PersistentCacheSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/eclipsestore/docs/PersistentCacheSpec.groovy
@@ -1,0 +1,36 @@
+package io.micronaut.eclipsestore.docs
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.Specification
+
+class PersistentCacheSpec extends Specification {
+
+    void "backed cache persists over restarts"() {
+        given:
+        def config = [storageDirectory: "build/eclipsestore-cache-${UUID.randomUUID()}"]
+        def server = ApplicationContext.run(EmbeddedServer.class, config, "cachepersist")
+        def counter = server.applicationContext.getBean(CounterService)
+
+        when:
+        counter.setCount("Tim", 1337L)
+        Long count = counter.currentCount("Tim")
+
+        then:
+        count == 1337
+
+        when:
+        counter.setCount("Tim", 666L);
+
+        and: "we restart the server"
+        server.stop()
+        server = ApplicationContext.run(EmbeddedServer.class, config, "cachepersist")
+        counter = server.applicationContext.getBean(CounterService)
+
+        and: "we get the count"
+        count = counter.currentCount("Tim")
+
+        then:
+        count == 666
+    }
+}

--- a/test-suite-groovy/src/test/resources/application-cache.yml
+++ b/test-suite-groovy/src/test/resources/application-cache.yml
@@ -1,0 +1,5 @@
+eclipsestore:
+  cache:
+    counter: # <1>
+      key-type: java.lang.String
+      value-type: java.lang.Long

--- a/test-suite-groovy/src/test/resources/application-cachepersist.yml
+++ b/test-suite-groovy/src/test/resources/application-cachepersist.yml
@@ -1,0 +1,10 @@
+eclipsestore:
+  storage:
+    backing: # <1>
+      storage-directory: "${storageDirectory}"
+      channel-count: 4
+  cache:
+    counter: # <2>
+      key-type: java.lang.String
+      value-type: java.lang.Long
+      storage: backing # <3>

--- a/test-suite-kotlin/build.gradle
+++ b/test-suite-kotlin/build.gradle
@@ -8,24 +8,26 @@ dependencies {
     kaptTest(platform(mn.micronaut.core.bom))
     kaptTest(projects.micronautEclipsestoreAnnotations)
     kaptTest(mnSerde.micronaut.serde.processor)
-
-    testImplementation(platform(mn.micronaut.core.bom))
-    testImplementation(projects.micronautEclipsestoreAnnotations)
-
-    testImplementation(mnValidation.micronaut.validation)
-    testImplementation(mnSerde.micronaut.serde.jackson)
-
-    testImplementation(libs.jupiter.api)
-    testImplementation(mnTest.micronaut.test.junit5)
-    testRuntimeOnly(libs.junit.jupiter.engine)
-    testRuntimeOnly(mnLogging.logback.classic)
-    testImplementation libs.kotlin.stdlib
     kaptTest(mn.micronaut.inject.java)
 
-    testImplementation(mn.micronaut.http.server.netty)
-    testImplementation(mn.micronaut.http.client)
     testImplementation(projects.micronautEclipsestore)
+    testImplementation(projects.micronautEclipsestoreAnnotations)
+    testImplementation(projects.micronautEclipsestoreCache)
+
+    testImplementation(libs.kotlin.stdlib)
+    testImplementation(libs.jupiter.api)
     testImplementation(libs.jupiter.jupiter.params)
+
+    testImplementation(mn.micronaut.http.client)
+    testImplementation(mn.micronaut.http.server.netty)
+    testImplementation(mnSerde.micronaut.serde.jackson)
+    testImplementation(mnTest.micronaut.test.junit5)
+    testImplementation(mnValidation.micronaut.validation)
+    testImplementation(platform(mn.micronaut.core.bom))
+
+    testRuntimeOnly(libs.junit.jupiter.engine)
+    testRuntimeOnly(mn.snakeyaml)
+    testRuntimeOnly(mnLogging.logback.classic)
 }
 
 kotlin {

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/eclipsestore/docs/CacheTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/eclipsestore/docs/CacheTest.kt
@@ -1,0 +1,28 @@
+package io.micronaut.eclipsestore.docs
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.runtime.server.EmbeddedServer
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class CacheTest {
+
+    @Test
+    fun cacheWorksAsExpected() {
+        val config = mapOf("storageDirectory" to "build/eclipsestore-cache-${UUID.randomUUID()}")
+        ApplicationContext.run(EmbeddedServer::class.java, config, "cache").use {
+            val counter = it.applicationContext.getBean(CounterService::class.java)
+            counter.setCount("Tim", 1337)
+
+            var currentCount = counter.currentCount("Tim")
+            assertEquals(1337, currentCount)
+
+            // Change the value in the map to check we are using the cache
+            counter.counters["Tim"] = 42
+
+            currentCount = counter.currentCount("Tim")
+            assertEquals(1337, currentCount)
+        }
+    }
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/eclipsestore/docs/CounterService.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/eclipsestore/docs/CounterService.kt
@@ -1,0 +1,23 @@
+package io.micronaut.eclipsestore.docs
+
+import io.micronaut.cache.annotation.CacheConfig
+import io.micronaut.cache.annotation.CachePut
+import io.micronaut.cache.annotation.Cacheable
+import jakarta.inject.Singleton
+import java.util.HashMap
+
+@Singleton
+@CacheConfig("counter") // <1>
+open class CounterService {
+
+    val counters: MutableMap<String, Long> = HashMap()
+
+    @Cacheable // <2>
+    open fun currentCount(name: String): Long? = counters[name]
+
+    @CachePut(parameters = ["name"]) // <3>
+    open fun setCount(name: String, count: Long): Long {
+        counters[name] = count
+        return count
+    }
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/eclipsestore/docs/PersistentCacheTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/eclipsestore/docs/PersistentCacheTest.kt
@@ -1,0 +1,27 @@
+package io.micronaut.eclipsestore.docs
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.runtime.server.EmbeddedServer
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class PersistentCacheTest {
+
+    @Test
+    fun cachePersistsOverRestarts() {
+        val config = mapOf("storageDirectory" to "build/eclipsestore-cache-${UUID.randomUUID()}")
+        ApplicationContext.run(EmbeddedServer::class.java, config, "cachepersist").use {
+            val counter = it.applicationContext.getBean(CounterService::class.java)
+            counter.setCount("Tim", 1337)
+            val count = counter.currentCount("Tim")
+            assertEquals(1337, count)
+            counter.setCount("Tim", 666)
+        }
+        ApplicationContext.run(EmbeddedServer::class.java, config, "cachepersist").use {
+            val counter = it.applicationContext.getBean(CounterService::class.java)
+            val count = counter.currentCount("Tim")
+            assertEquals(666, count)
+        }
+    }
+}

--- a/test-suite-kotlin/src/test/resources/application-cache.yml
+++ b/test-suite-kotlin/src/test/resources/application-cache.yml
@@ -1,0 +1,5 @@
+eclipsestore:
+  cache:
+    counter: # <1>
+      key-type: java.lang.String
+      value-type: java.lang.Long

--- a/test-suite-kotlin/src/test/resources/application-cachepersist.yml
+++ b/test-suite-kotlin/src/test/resources/application-cachepersist.yml
@@ -1,0 +1,10 @@
+eclipsestore:
+  storage:
+    backing: # <1>
+      storage-directory: "${storageDirectory}"
+      channel-count: 4
+  cache:
+    counter: # <2>
+      key-type: java.lang.String
+      value-type: java.lang.Long
+      storage: backing # <3>

--- a/test-suite/build.gradle
+++ b/test-suite/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     testImplementation(mnSerde.micronaut.serde.jackson)
 
     testImplementation(projects.micronautEclipsestoreAnnotations)
+    testImplementation(projects.micronautEclipsestoreCache)
 
     testImplementation(libs.jupiter.api)
     testImplementation(mnTest.micronaut.test.junit5)

--- a/test-suite/src/test/java/io/micronaut/eclipsestore/docs/CacheTest.java
+++ b/test-suite/src/test/java/io/micronaut/eclipsestore/docs/CacheTest.java
@@ -1,0 +1,33 @@
+package io.micronaut.eclipsestore.docs;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.runtime.server.EmbeddedServer;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CacheTest {
+
+    @Test
+    void cacheWorksAsExpected() {
+        Map<String, Object> config = CollectionUtils.mapOf(
+            "storageDirectory", "build/eclipsestore-cache-" + UUID.randomUUID()
+        );
+        // When we create the app, and use a cached method
+        try (EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, config, "cache")) {
+            CounterService counter = server.getApplicationContext().getBean(CounterService.class);
+            counter.setCount("Tim", 1337L);
+            Long count = counter.currentCount("Tim");
+            assertEquals(1337L, count);
+
+            // Change the store so we check we're seeing a cached value
+            counter.counters.put("Tim", -1L);
+            count = counter.currentCount("Tim");
+            assertEquals(1337L, count);
+        }
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/eclipsestore/docs/CounterService.java
+++ b/test-suite/src/test/java/io/micronaut/eclipsestore/docs/CounterService.java
@@ -1,0 +1,27 @@
+package io.micronaut.eclipsestore.docs;
+
+import io.micronaut.cache.annotation.CacheConfig;
+import io.micronaut.cache.annotation.CachePut;
+import io.micronaut.cache.annotation.Cacheable;
+import jakarta.inject.Singleton;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Singleton
+@CacheConfig("counter") // <1>
+public class CounterService {
+
+    Map<String, Long> counters = new HashMap<>();
+
+    @Cacheable // <2>
+    public Long currentCount(String name) {
+        return counters.get(name);
+    }
+
+    @CachePut(parameters = {"name"}) // <3>
+    public Long setCount(String name, Long count) {
+        counters.put(name, count);
+        return count;
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/eclipsestore/docs/DynamoDbPersistentCacheTest.java
+++ b/test-suite/src/test/java/io/micronaut/eclipsestore/docs/DynamoDbPersistentCacheTest.java
@@ -1,0 +1,56 @@
+package io.micronaut.eclipsestore.docs;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.eclipsestore.testutils.DynamoDbLocal;
+import io.micronaut.runtime.server.EmbeddedServer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Testcontainers
+class DynamoDbPersistentCacheTest {
+
+    public static boolean dockerAvailable() {
+        return DockerClientFactory.instance().isDockerAvailable();
+    }
+
+    @Container
+    public final DynamoDbLocal dynamoDbLocal = new DynamoDbLocal();
+
+    @EnabledIf("dockerAvailable")
+    @Test
+    void cachePersistsOverRestarts() {
+        var config = new HashMap<>(dynamoDbLocal.getProperties());
+        config.putAll(Map.of(
+            "micronaut.metrics.enabled", StringUtils.FALSE,
+            "eclipsestore.dynamodb.storage.cache.table-name", "eclipsestore",
+            "eclipsestore.cache.counter.key-type", "java.lang.String",
+            "eclipsestore.cache.counter.value-type", "java.lang.Long",
+            "eclipsestore.cache.counter.storage", "cache"
+        ));
+
+        // When we create the app, and use a cached method
+        try (EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, config)) {
+            CounterService counter = server.getApplicationContext().getBean(CounterService.class);
+            counter.setCount("Tim", 1337L);
+            Long count = counter.currentCount("Tim");
+            assertEquals(1337L, count);
+            counter.setCount("Tim", 666L);
+        }
+
+        // Then restarting the app with the same storage location, the value is still cached
+        try (EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, config)) {
+            CounterService counter = server.getApplicationContext().getBean(CounterService.class);
+            Long count = counter.currentCount("Tim");
+            assertEquals(666L, count);
+        }
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/eclipsestore/docs/PersistentCacheTest.java
+++ b/test-suite/src/test/java/io/micronaut/eclipsestore/docs/PersistentCacheTest.java
@@ -1,0 +1,36 @@
+package io.micronaut.eclipsestore.docs;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.runtime.server.EmbeddedServer;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PersistentCacheTest {
+
+    @Test
+    void cachePersistsOverRestarts() {
+        Map<String, Object> config = CollectionUtils.mapOf(
+            "storageDirectory", "build/eclipsestore-cache-" + UUID.randomUUID()
+        );
+        // When we create the app, and use a cached method
+        try (EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, config, "cachepersist")) {
+            CounterService counter = server.getApplicationContext().getBean(CounterService.class);
+            counter.setCount("Tim", 1337L);
+            Long count = counter.currentCount("Tim");
+            assertEquals(1337L, count);
+            counter.setCount("Tim", 666L);
+        }
+
+        // Then restarting the app with the same storage location, the value is still cached
+        try (EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, config, "cachepersist")) {
+            CounterService counter = server.getApplicationContext().getBean(CounterService.class);
+            Long count = counter.currentCount("Tim");
+            assertEquals(666L, count);
+        }
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/eclipsestore/docs/PostgresPersistentCacheTest.java
+++ b/test-suite/src/test/java/io/micronaut/eclipsestore/docs/PostgresPersistentCacheTest.java
@@ -1,0 +1,47 @@
+package io.micronaut.eclipsestore.docs;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.runtime.server.EmbeddedServer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.testcontainers.DockerClientFactory;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PostgresPersistentCacheTest {
+    public static boolean dockerAvailable() {
+        return DockerClientFactory.instance().isDockerAvailable();
+    }
+
+    @EnabledIf("dockerAvailable")
+    @Test
+    void cachePersistsOverRestarts() {
+        Map<String, Object> config = Map.of(
+            "datasources.cache.db-type", "postgresql",
+            "micronaut.metrics.enabled", StringUtils.FALSE,
+            "eclipsestore.postgres.storage.cache.table-name", "eclipsestore",
+            "eclipsestore.cache.counter.key-type", "java.lang.String",
+            "eclipsestore.cache.counter.value-type", "java.lang.Long",
+            "eclipsestore.cache.counter.storage", "cache"
+        );
+
+        // When we create the app, and use a cached method
+        try (EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, config)) {
+            CounterService counter = server.getApplicationContext().getBean(CounterService.class);
+            counter.setCount("Tim", 1337L);
+            Long count = counter.currentCount("Tim");
+            assertEquals(1337L, count);
+            counter.setCount("Tim", 666L);
+        }
+
+        // Then restarting the app with the same storage location, the value is still cached
+        try (EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, config)) {
+            CounterService counter = server.getApplicationContext().getBean(CounterService.class);
+            Long count = counter.currentCount("Tim");
+            assertEquals(666L, count);
+        }
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/eclipsestore/docs/S3PersistentCacheTest.java
+++ b/test-suite/src/test/java/io/micronaut/eclipsestore/docs/S3PersistentCacheTest.java
@@ -1,0 +1,61 @@
+package io.micronaut.eclipsestore.docs;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.eclipsestore.testutils.MinioLocal;
+import io.micronaut.runtime.server.EmbeddedServer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Testcontainers
+class S3PersistentCacheTest {
+
+    private static final String BUCKET_NAME = "eclipsestorecache";
+
+    @Container
+    MinioLocal minioLocal = new MinioLocal();
+
+    public static boolean dockerAvailable() {
+        return DockerClientFactory.instance().isDockerAvailable();
+    }
+
+    @EnabledIf("dockerAvailable")
+    @Test
+    void cachePersistsOverRestarts() {
+        var config = new HashMap<>(minioLocal.getProperties());
+
+        config.putAll(Map.of(
+            "s3.test", StringUtils.TRUE,
+            "micronaut.metrics.enabled", StringUtils.FALSE,
+            "aws.bucket-name", BUCKET_NAME,
+            "eclipsestore.cache.counter.key-type", "java.lang.String",
+            "eclipsestore.cache.counter.value-type", "java.lang.Long",
+            "eclipsestore.cache.counter.storage", "cache",
+            "eclipsestore.s3.storage.cache.bucket-name", BUCKET_NAME
+        ));
+
+        // When we create the app, and use a cached method
+        try (EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, config)) {
+            CounterService counter = server.getApplicationContext().getBean(CounterService.class);
+            counter.setCount("Tim", 1337L);
+            Long count = counter.currentCount("Tim");
+            assertEquals(1337L, count);
+            counter.setCount("Tim", 666L);
+        }
+
+        // Then restarting the app with the same storage location, the value is still cached
+        try (EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, config)) {
+            CounterService counter = server.getApplicationContext().getBean(CounterService.class);
+            Long count = counter.currentCount("Tim");
+            assertEquals(666L, count);
+        }
+    }
+}

--- a/test-suite/src/test/resources/application-cache.yml
+++ b/test-suite/src/test/resources/application-cache.yml
@@ -1,0 +1,5 @@
+eclipsestore:
+  cache:
+    counter: # <1>
+      key-type: java.lang.String
+      value-type: java.lang.Long

--- a/test-suite/src/test/resources/application-cachepersist.yml
+++ b/test-suite/src/test/resources/application-cachepersist.yml
@@ -1,0 +1,10 @@
+eclipsestore:
+  storage:
+    backing: # <1>
+      storage-directory: "${storageDirectory}"
+      channel-count: 4
+  cache:
+    counter: # <2>
+      key-type: java.lang.String
+      value-type: java.lang.Long
+      storage: backing # <3>


### PR DESCRIPTION
For v1.3.0 of this module, we can upgrade EclipseStore to 1.1.0 and re-introduce caching