### PR TITLE
Upgrade eclipsestore dep to `1.2.0` and use GraalVM `21` again.

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['17', '21.0.1']
+        java: ['17', '21']
     env:
       GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ micronaut = "4.3.1"
 groovy = "4.0.17"
 kotlin = '1.9.22'
 spock = "2.3-groovy-4.0"
-managed-eclipsestore='1.1.0'
+managed-eclipsestore='1.2.0'
 
 micronaut-aws = "4.4.0"
 micronaut-cache = "4.2.1"


### PR DESCRIPTION
This PR updates the eclipsestore dependency to 1.2.0, which includes a [fix that prevents crashed on JDK 21.0.2](https://github.com/eclipse-serializer/serializer/pull/103). With that, it should be possible to use GraalVM `21` instead of `21.0.1` again.

cc @timyates @graemerocher