### PR TITLE
build: update to eclipsestore 1.3.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ micronaut = "4.5.1"
 groovy = "4.0.17"
 kotlin = '1.9.24'
 spock = "2.3-groovy-4.0"
-managed-eclipsestore='1.3.1'
+managed-eclipsestore='1.3.2'
 
 micronaut-aws = "4.5.0"
 micronaut-cache = "4.3.0"


### PR DESCRIPTION
See: https://github.com/eclipse-store/store/issues/223

Steps to reproduce. 

Clone branch `eclipsestore_1_3_2` in the repository https://github.com/micronaut-projects/micronaut-eclipsestore

Run `./gradlew :micronaut-eclipsestore:test --tests "io.micronaut.eclipsestore.s3.S3StorageSpec"`

The test fails with: 

```

io.micronaut.context.exceptions.BeanInstantiationException: Error instantiating bean of type  [io.micronaut.eclipsestore.BaseStorageSpec$CustomerRepository]

Message: The authorization mechanism you have provided is not supported. Please use AWS4-HMAC-SHA256. (Service: S3, Status Code: 400, Request ID: 17D590734D1B49AA, Extended Request ID: dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8)
Path Taken: S3StorageSpec.setCustomerRepository([CustomerRepository customerRepository]) --> new CustomerRepository([StorageManager storageManager])
	at app//io.micronaut.context.DefaultBeanContext.resolveByBeanFactory(DefaultBeanContext.java:2331)
	at app//io.micronaut.context.DefaultBeanContext.doCreateBean(DefaultBeanContext.java:2286)
	at app//io.micronaut.context.DefaultBeanContext.doCreateBean(DefaultBeanContext.java:2298)

```

I assume this is caused by : 

https://github.com/eclipse-store/store/pull/197